### PR TITLE
Correct homepage development branch on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ deploy:
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_DEVELOPMENT"
   region: us-east-1
   app: nypl-homepage-app
-  env: nypl-homepage-dev
+  env: nypl-homepage-development
   bucket_name: elasticbeanstalk-us-east-1-224280085904
-  bucket_path: nypl-homepage-dev
+  bucket_path: nypl-homepage-development
   on:
     repo: NYPL/dgx-homepage
     branch: development


### PR DESCRIPTION
Brett has changed the CNAME for `dev-homepage.nypl.org` to point to the new Elastic Beanstalk instance `nypl-homepage-development.us-east-1.elasticbeanstalk.com` on `nypl-sandbox`, hence the changes reflect on Travis configuration. Thank you!