### PR TITLE
hero banner button

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Going from the top to the bottom of the page, we have the following list of comp
 
 | Component | Repo |
 |---|---|
-| Content Banner | [dgx-homepage-content-banner](https://bitbucket.org/NYPL/dgx-homepage-content-banner) |
 | What's Happening | [dgx-tabbed-features-component](https://bitbucket.org/NYPL/dgx-tabbed-features-component) |
 | Learn Something New | [dgx-feature-row-component](https://bitbucket.org/NYPL/dgx-feature-row-component) |
 | Staff Picks | [dgx-homepage-staff-picks-component](https://bitbucket.org/NYPL/dgx-homepage-staff-picks-component) |

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -57,7 +57,7 @@ class App extends React.Component {
       <div className="nyplHomepageApp">
         <Header navData={navConfig.current} skipNav={{ target: 'mainContent' }} />
 
-        <main className="nyplHomepage" id="mainContent" tabIndex="-1">
+        <main className="nyplHomepage" id="mainContent">
           <ContentBanner
             ref={i => (this.ContentBanner = i)}
             items={bannerData.slots}

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -57,7 +57,7 @@ class App extends React.Component {
       <div className="nyplHomepageApp">
         <Header navData={navConfig.current} skipNav={{ target: 'mainContent' }} />
 
-        <div className="nyplHomepage" id="mainContent" tabIndex="-1">
+        <main className="nyplHomepage" id="mainContent" tabIndex="-1">
           <ContentBanner
             ref={i => (this.ContentBanner = i)}
             items={bannerData.slots}
@@ -171,7 +171,7 @@ class App extends React.Component {
               />
             }
           />
-        </div>
+        </main>
 
         <Footer id="footer" className="footer" />
       </div>

--- a/src/app/components/ContentBanner/ContentBanner.jsx
+++ b/src/app/components/ContentBanner/ContentBanner.jsx
@@ -19,6 +19,7 @@ class ContentBanner extends React.Component {
 
     this.handleResize = this.handleResize.bind(this);
     this.renderContentBanner = this.renderContentBanner.bind(this);
+    this.handleGAClickEvent = this.handleGAClickEvent.bind(this);
   }
 
   componentDidMount() {
@@ -53,12 +54,22 @@ class ContentBanner extends React.Component {
           description={item.description}
           date={item.date}
           location={item.location}
-          gaClickEvent={this.props.gaClickEvent}
+          gaClickEvent={this.handleGAClickEvent}
+          buttonText={item.buttonText}
         />
       </div>
     );
 
     return content;
+  }
+
+  handleGAClickEvent(action, label, event) {
+    if (event) {
+      event.stopPropagation();
+    }
+    if (action && label) {
+      this.props.gaClickEvent(action, label);
+    }
   }
 
   /**

--- a/src/app/components/ContentBanner/ImageItem.jsx
+++ b/src/app/components/ContentBanner/ImageItem.jsx
@@ -116,7 +116,6 @@ class ImageItem extends React.Component {
         alt={alt}
         onLoad={this.handleOnLoad}
         onError={this.handleOnError}
-        tabIndex="0"
       />
     );
   }

--- a/src/app/components/ContentBanner/TextItem.jsx
+++ b/src/app/components/ContentBanner/TextItem.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { RightArrowIcon } from '@nypl/dgx-svg-icons';
 
 /**
   * @desc Verifies that the property value exists and returns it.
@@ -52,7 +53,7 @@ const TextItem = ({
         href={content.url}
         onClick={gaClickEvent ? () => gaClickEvent('Hero', content.url) : null}
       >
-        <span className={`${className}-tag`} aria-hidden="true">{content.tag}</span>
+        <span className={`${className}-tag`}>{content.tag}</span>
         <h1 className={`${className}-title`}>{content.title}</h1>
         {
           (content.date || content.location) ?
@@ -67,6 +68,10 @@ const TextItem = ({
               {content.desc ? <p>{content.desc}</p> : null}
             </div>
         }
+      </a>
+      <a href="#" className="seeMoreLink">
+        Donate
+        <RightArrowIcon ariaHidden />
       </a>
     </div>
   );

--- a/src/app/components/ContentBanner/TextItem.jsx
+++ b/src/app/components/ContentBanner/TextItem.jsx
@@ -77,7 +77,6 @@ const TextItem = ({
         <div className="seeMoreLink-container">
           <div
             className="seeMoreLink"
-            onClick={gaClickEvent ? (e) => gaClickEvent('Hero button', content.url, e) : null}
           >
             {buttonTextElm}
             <RightArrowIcon ariaHidden />

--- a/src/app/components/ContentBanner/TextItem.jsx
+++ b/src/app/components/ContentBanner/TextItem.jsx
@@ -74,15 +74,15 @@ const TextItem = ({
               {content.desc ? <p>{content.desc}</p> : null}
             </div>
         }
-        <button
-          href="#"
-          className="seeMoreLink"
-          tabIndex="-1"
-          onClick={gaClickEvent ? (e) => gaClickEvent('Hero button', content.url, e) : null}
-        >
-          {buttonTextElm}
-          <RightArrowIcon ariaHidden />
-        </button>
+        <div className="seeMoreLink-container">
+          <div
+            className="seeMoreLink"
+            onClick={gaClickEvent ? (e) => gaClickEvent('Hero button', content.url, e) : null}
+          >
+            {buttonTextElm}
+            <RightArrowIcon ariaHidden />
+          </div>
+        </div>
       </a>
     </div>
   );

--- a/src/app/components/ContentBanner/TextItem.jsx
+++ b/src/app/components/ContentBanner/TextItem.jsx
@@ -37,6 +37,7 @@ const TextItem = ({
   date,
   lang,
   gaClickEvent,
+  buttonText,
 }) => {
   const content = {
     url: getString(target, '#'),
@@ -45,7 +46,12 @@ const TextItem = ({
     desc: getProperty(description, lang),
     date: getProperty(date, lang),
     location: getString(location),
+    buttonText: getProperty(buttonText, lang),
   };
+  let buttonTextElm = null;
+  if (content.buttonText) {
+    buttonTextElm = (<span className="btn-text">{content.buttonText}</span>);
+  }
 
   return (
     <div className={className}>
@@ -68,10 +74,15 @@ const TextItem = ({
               {content.desc ? <p>{content.desc}</p> : null}
             </div>
         }
-      </a>
-      <a href="#" className="seeMoreLink">
-        Donate
-        <RightArrowIcon ariaHidden />
+        <button
+          href="#"
+          className="seeMoreLink"
+          tabIndex="-1"
+          onClick={gaClickEvent ? (e) => gaClickEvent('Hero button', content.url, e) : null}
+        >
+          {buttonTextElm}
+          <RightArrowIcon ariaHidden />
+        </button>
       </a>
     </div>
   );
@@ -87,6 +98,7 @@ TextItem.propTypes = {
   date: PropTypes.object,
   description: PropTypes.object,
   gaClickEvent: PropTypes.func,
+  buttonText: PropTypes.object,
 };
 
 TextItem.defaultProps = {

--- a/src/app/components/ContentBanner/TextItem.jsx
+++ b/src/app/components/ContentBanner/TextItem.jsx
@@ -77,6 +77,7 @@ const TextItem = ({
         <div className="seeMoreLink-container">
           <div
             className="seeMoreLink"
+            onClick={gaClickEvent ? (e) => gaClickEvent('Hero button', content.url, e) : null}
           >
             {buttonTextElm}
             <RightArrowIcon ariaHidden />

--- a/src/app/utils/Model.js
+++ b/src/app/utils/Model.js
@@ -360,6 +360,37 @@ function Model() {
     return result;
   };
 
+  this.getButtonText = obj => {
+    let result;
+    if (!obj && _isEmpty(obj)) {
+      return undefined;
+    }
+
+    try {
+      const {
+        attributes: {
+          "button-text": {
+            en: {
+              text: text = '',
+              type: type = '',
+            },
+          },
+        },
+      } = obj;
+
+      result = {
+        en: {
+          type,
+          text,
+        },
+      };
+    } catch (e) {
+      result = undefined;
+    }
+
+    return result;
+  };
+
   this.getImageAlt = image => {
     if (!image && _isEmpty(image)) {
       return '';
@@ -439,6 +470,7 @@ function Model() {
       const authorImage = this.getAuthorImage(currentItem);
       const fullName = this.getAuthorFullName(currentItem);
       const bookItem = this.getBookItem(currentItem);
+      const buttonText = this.getButtonText(currentItem);
 
       return {
         title: (currentItem.attributes.title) ?
@@ -466,6 +498,7 @@ function Model() {
         },
         location,
         bookItem,
+        buttonText,
       };
     });
   };

--- a/src/client/styles/components/_ContentBanner.scss
+++ b/src/client/styles/components/_ContentBanner.scss
@@ -250,17 +250,17 @@
       right: 15px;
 
       @include Kievit-Medium;
-      border: 2px solid $WHITE;
-      border-radius: 22px;
+      border: 2px solid #000;
+      border-radius: 37px;
       color: #000;
       background: $WHITE;
       text-decoration: none;
       position: absolute;
-      height: 35px;
+      height: 37px;
       padding: 0 4px;
       text-align: center;
       vertical-align: middle;
-      font-size: 0.8rem;
+      font-size: 1rem;
 
       @include min-screen(380px) {
         top: 80%;
@@ -277,7 +277,7 @@
       @include min-screen($tablet-portrait) {
         border: 2px solid #333;
         background: #333;
-        border-radius: 22px;
+        border-radius: 37px;
         color: $WHITE;
         top: 75%;
         right: 45%;
@@ -287,9 +287,13 @@
       }
 
       span {
-        top: -7px;
-        position: relative;
         padding: 0 5px;
+        @include visuallyHidden;
+
+        @include min-screen($tablet-portrait) {
+          top: -7px;
+          @include displayVisuallyHidden;
+        }
       }
 
       svg {

--- a/src/client/styles/components/_ContentBanner.scss
+++ b/src/client/styles/components/_ContentBanner.scss
@@ -105,33 +105,30 @@
       display: block;
       width: 62%;
 
+      &:focus,
       &:hover {
         h1 {
           text-decoration: underline;
         }
 
-        .seeMoreLink {
-          border: 2px solid #000;
-
-          svg {
-            fill: #000;
+        @include min-screen($tablet-portrait) {
+          .seeMoreLink {
+            border: 2px solid $WHITE;
           }
         }
+      }
+
+      &:hover {
+        outline: -webkit-focus-ring-color auto 5px;
+        outline: -moz-focus-ring-color auto 5px;
+        outline: -o-focus-ring-color auto 5px;
+        outline: -ms-focus-ring-color auto 5px;
       }
 
       @include min-screen($tablet-portrait) {
         background-color: #333;
         padding: 15px;
         width: 55%;
-        &:hover {
-          .seeMoreLink {
-            border: 2px solid $WHITE;
-
-            svg {
-              fill: $WHITE;
-            }
-          }
-        }
       }
 
       @include min-screen($tablet-landscape + 1px) {
@@ -250,7 +247,7 @@
       right: 15px;
 
       @include Kievit-Medium;
-      border: 2px solid #000;
+      border: 2px solid $PRIMARY_COLOR;
       border-radius: 37px;
       color: #000;
       background: $WHITE;
@@ -297,7 +294,7 @@
       }
 
       svg {
-        fill: #000;
+        fill: $PRIMARY_COLOR;
         height: 25px;
         position: relative;
         top: 1px;

--- a/src/client/styles/components/_ContentBanner.scss
+++ b/src/client/styles/components/_ContentBanner.scss
@@ -4,9 +4,11 @@
   margin: 0 auto;
   overflow: hidden;
   width: 100%;
+  padding-bottom: 10px;
 
   @include min-screen($tablet-portrait) {
     margin-bottom: 15px;
+    padding-bottom: 0px;
   }
 
   @include min-screen($desktop) {

--- a/src/client/styles/components/_ContentBanner.scss
+++ b/src/client/styles/components/_ContentBanner.scss
@@ -246,11 +246,15 @@
 
     .seeMoreLink-container {
       position: relative;
-      height: 40px;
+      height: 0;
+
+      @include min-screen($tablet-portrait) {
+        height: 40px;
+      }
     }
 
     .seeMoreLink {
-      top: -5.5rem;
+      top: -4.5rem;
       right: -5.5rem;
 
       @include Kievit-Medium;
@@ -271,7 +275,6 @@
         right: -8rem;
       }
       @include min-screen(480px) {
-        top: -4rem;
         right: -10rem;
       }
       @include min-screen(600px) {

--- a/src/client/styles/components/_ContentBanner.scss
+++ b/src/client/styles/components/_ContentBanner.scss
@@ -144,7 +144,7 @@
 
       @include min-screen($tablet-portrait) {
         color: #FFF;
-        margin-top: 25px;
+        margin-top: 15px;
       }
 
       @include min-screen($desktop) {
@@ -222,7 +222,7 @@
     }
 
     .seeMoreLink {
-      top: 84%;
+      top: 83%;
       right: 15px;
 
       @include Kievit-Medium;
@@ -238,10 +238,21 @@
       text-align: center;
       vertical-align: middle;
 
+      @include min-screen(528px) {
+        top: 86%;
+      }
       @include min-screen($tablet-portrait) {
-        top: 170px;
-        margin-left: 40%;
+        top: 205px;
+        margin-left: 39%;
         right: auto;
+      }
+      @include min-screen($tablet-landscape) {
+        top: 185px;
+        margin-left: 40%;
+      }
+      @include min-screen($desktop) {
+        top: 220px;
+        margin-left: 43%;
       }
 
       &:hover {

--- a/src/client/styles/components/_ContentBanner.scss
+++ b/src/client/styles/components/_ContentBanner.scss
@@ -82,7 +82,7 @@
       padding: 0;
       position: absolute;
       left: 18%;
-      top: 65px;
+      top: 15px;
       color: #FFF;
     }
 
@@ -202,15 +202,63 @@
         color: #FFF;
         width: auto; // Override displayVisuallyHidden width rule
         margin: 25px 0 0;
+
+        p {
+          width: 65%;
+        }
       }
 
       @include min-screen($tablet-landscape + 1px) {
-        max-width: 100%;
+        max-width: 60%;
+        p {
+          width: 100%;
+        }
       }
 
       @include min-screen($desktop) {
         margin-top: 30px;
-        max-width: 420px;
+        max-width: 300px;
+      }
+    }
+
+    .seeMoreLink {
+      top: 84%;
+      right: 15px;
+
+      @include Kievit-Medium;
+      border: 2px solid $PRIMARY_COLOR;
+      border-radius: 22px;
+      color: $PRIMARY_COLOR;
+      background: $WHITE;
+      text-decoration: none;
+      width: 85px;
+      position: absolute;
+      height: 30px;
+      padding: 3px 15px 13px;
+      text-align: center;
+      vertical-align: middle;
+
+      @include min-screen($tablet-portrait) {
+        top: 170px;
+        margin-left: 40%;
+        right: auto;
+      }
+
+      &:hover {
+        border: 2px solid $TERTIARY_BLUE_COLOR;
+        color: $TERTIARY_BLUE_COLOR;
+
+        svg {
+          fill: $TERTIARY_BLUE_COLOR;
+        }
+      }
+
+      svg {
+        fill: $PRIMARY_COLOR;
+        height: 25px;
+        position: relative;
+        top: 8px;
+        width: 25px;
       }
     }
   }

--- a/src/client/styles/components/_ContentBanner.scss
+++ b/src/client/styles/components/_ContentBanner.scss
@@ -244,45 +244,53 @@
       }
     }
 
+    .seeMoreLink-container {
+      position: relative;
+      height: 40px;
+    }
+
     .seeMoreLink {
-      top: 75%;
-      right: 15px;
+      top: -5.5rem;
+      right: -5.5rem;
 
       @include Kievit-Medium;
       border: 2px solid $PRIMARY_COLOR;
-      border-radius: 37px;
+      border-radius: 27px;
       color: #000;
       background: $WHITE;
       text-decoration: none;
       position: absolute;
-      height: 37px;
-      padding: 0 4px;
+      height: 27px;
+      padding: 3px 4px;
       text-align: center;
       vertical-align: middle;
       font-size: 1rem;
 
       @include min-screen(380px) {
-        top: 80%;
+        top: -3rem;
+        right: -8rem;
       }
-
       @include min-screen(480px) {
-        top: 85%;
+        top: -4rem;
+        right: -10rem;
       }
-
       @include min-screen(600px) {
-        top: 90%;
+        right: -12rem;
+      }
+      @include min-screen(800px) {
+        top: -3rem;
+        right: -15.5rem;
       }
 
       @include min-screen($tablet-portrait) {
         border: 2px solid #333;
         background: #333;
-        border-radius: 37px;
+        border-radius: 27px;
         color: $WHITE;
-        top: 75%;
-        right: 45%;
-      }
-      @include min-screen($tablet-landscape) {
-        right: 48%;
+        float: right;
+        right: auto;
+        position: relative;
+        top: auto;
       }
 
       span {

--- a/src/client/styles/components/_ContentBanner.scss
+++ b/src/client/styles/components/_ContentBanner.scss
@@ -82,7 +82,7 @@
       padding: 0;
       position: absolute;
       left: 18%;
-      top: 15px;
+      top: 30px;
       color: #FFF;
     }
 
@@ -101,13 +101,37 @@
 
     a {
       background-color: #FFF;
+      color: $WHITE;
       display: block;
       width: 62%;
+
+      &:hover {
+        h1 {
+          text-decoration: underline;
+        }
+
+        .seeMoreLink {
+          border: 2px solid #000;
+
+          svg {
+            fill: #000;
+          }
+        }
+      }
 
       @include min-screen($tablet-portrait) {
         background-color: #333;
         padding: 15px;
         width: 55%;
+        &:hover {
+          .seeMoreLink {
+            border: 2px solid $WHITE;
+
+            svg {
+              fill: $WHITE;
+            }
+          }
+        }
       }
 
       @include min-screen($tablet-landscape + 1px) {
@@ -201,7 +225,7 @@
         @include displayVisuallyHidden;
         color: #FFF;
         width: auto; // Override displayVisuallyHidden width rule
-        margin: 25px 0 0;
+        margin: 5px 0 0;
 
         p {
           width: 65%;
@@ -222,54 +246,62 @@
     }
 
     .seeMoreLink {
-      top: 83%;
+      top: 75%;
       right: 15px;
 
       @include Kievit-Medium;
-      border: 2px solid $PRIMARY_COLOR;
+      border: 2px solid $WHITE;
       border-radius: 22px;
-      color: $PRIMARY_COLOR;
+      color: #000;
       background: $WHITE;
       text-decoration: none;
-      width: 85px;
       position: absolute;
-      height: 30px;
-      padding: 3px 15px 13px;
+      height: 35px;
+      padding: 0 4px;
       text-align: center;
       vertical-align: middle;
+      font-size: 0.8rem;
 
-      @include min-screen(528px) {
-        top: 86%;
+      @include min-screen(380px) {
+        top: 80%;
       }
+
+      @include min-screen(480px) {
+        top: 85%;
+      }
+
+      @include min-screen(600px) {
+        top: 90%;
+      }
+
       @include min-screen($tablet-portrait) {
-        top: 205px;
-        margin-left: 39%;
-        right: auto;
+        border: 2px solid #333;
+        background: #333;
+        border-radius: 22px;
+        color: $WHITE;
+        top: 75%;
+        right: 45%;
       }
       @include min-screen($tablet-landscape) {
-        top: 185px;
-        margin-left: 40%;
-      }
-      @include min-screen($desktop) {
-        top: 220px;
-        margin-left: 43%;
+        right: 48%;
       }
 
-      &:hover {
-        border: 2px solid $TERTIARY_BLUE_COLOR;
-        color: $TERTIARY_BLUE_COLOR;
-
-        svg {
-          fill: $TERTIARY_BLUE_COLOR;
-        }
+      span {
+        top: -7px;
+        position: relative;
+        padding: 0 5px;
       }
 
       svg {
-        fill: $PRIMARY_COLOR;
+        fill: #000;
         height: 25px;
         position: relative;
-        top: 8px;
+        top: 1px;
         width: 25px;
+
+        @include min-screen($tablet-portrait) {
+          fill: $WHITE;
+        }
       }
     }
   }

--- a/src/client/styles/utils/_colors.scss
+++ b/src/client/styles/utils/_colors.scss
@@ -4,6 +4,8 @@
  * and set up the Ethyl Style Guide application.
 */
 
+$WHITE: #FFF;
+
 /* NYPL Primary Red */
 $PRIMARY_COLOR: #E32B31 !default;
 /* Secondry Red Color */


### PR DESCRIPTION
Fixes [WWW-431](https://jira.nypl.org/browse/WWW-431).

Basically,
- new right arrow button will always display on the hero banner on the homepage
- there will only be a border on the **hover** state for the whole content area
- parsed a new `button-text` property from the Refinery API and added it to the slot container if it is there.
- the button is _inside_ the anchor. In order to track GA clicks, the button has an `event.stopPropagation` call to prevent the GA event from being called twice. Click on the button will still trigger the link click since that isn't prevented.
- very minor styling tweaks to the content area

Currently up on dev and qa.
- dev - has no button text - https://dev-www.nypl.org/
- qa - should have button text - https://qa-www.nypl.org/

Some screenshots:
![screen shot 2018-10-11 at 4 52 40 pm](https://user-images.githubusercontent.com/1280564/46834664-034ecc00-cd7a-11e8-8e6b-2d51912b5435.png)
![screen shot 2018-10-11 at 4 52 13 pm](https://user-images.githubusercontent.com/1280564/46834670-08138000-cd7a-11e8-938a-ad682663075d.png)
![screen shot 2018-10-11 at 4 52 36 pm](https://user-images.githubusercontent.com/1280564/46834682-0d70ca80-cd7a-11e8-9dd2-bfe7bc89328e.png)
![screen shot 2018-10-11 at 4 52 25 pm](https://user-images.githubusercontent.com/1280564/46834683-0d70ca80-cd7a-11e8-810a-101474f23e45.png)
![screen shot 2018-10-11 at 4 52 20 pm](https://user-images.githubusercontent.com/1280564/46834684-0d70ca80-cd7a-11e8-80bc-0374be5a5446.png)
