### PR TITLE
RENO-1317: Hotfix for Safari bug that stretches images in mobile size

### DIFF
--- a/src/client/styles/components/_LearnSomethingNew_Flex.scss
+++ b/src/client/styles/components/_LearnSomethingNew_Flex.scss
@@ -14,6 +14,7 @@
   a {
     display: flex;
     justify-content: space-between;
+    align-items: flex-start;
     text-decoration: none;
     &:focus {
       outline: $focus-color solid 3px;


### PR DESCRIPTION
Fixes known bug in Safari that improperly stretches images in a flex container.
https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari