### PR TITLE
RENO-2025: Update NYPL from Home image urls

### DIFF
--- a/src/app/stores/NYPLfromHomeStore.js
+++ b/src/app/stores/NYPLfromHomeStore.js
@@ -12,7 +12,7 @@ const NYPLfromHomeData = {
         rectangularImage: {
           alt: "Closeup of someone holding an NYPL library card.",
           description: "",
-          'full-uri': "https://d2720ur5668dri.cloudfront.net/sites/default/files/styles/extralarge/public/sites/default/files/get_a_digital_library_card_today_cr.jpeg",
+          'full-uri': "https://ux-static.nypl.org/images/get_a_digital_library_card_today_cr.jpeg",
           type: "uri",
         }
       },
@@ -24,7 +24,7 @@ const NYPLfromHomeData = {
         rectangularImage: {
           alt: "Closeup of SimplyE interface on a phone screen.",
           description: "",
-          'full-uri': "https://d2720ur5668dri.cloudfront.net/sites/default/files/styles/extralarge/public/sites/default/files/ebooks_more_with_simplye_cr.jpeg",
+          'full-uri': "https://ux-static.nypl.org/images/ebooks_more_with_simplye_cr.jpeg",
           type: "uri",
         }
       },
@@ -36,7 +36,7 @@ const NYPLfromHomeData = {
         rectangularImage: {
           alt: "Woman smiling towards camera while using a computer",
           description: "",
-          'full-uri': "https://d2720ur5668dri.cloudfront.net/sites/default/files/styles/extralarge/public/sites/default/files/online_classes_events_cr.jpeg",
+          'full-uri': "https://ux-static.nypl.org/images/online_classes_events_cr.jpeg",
           type: "uri",
         }
       },
@@ -48,7 +48,7 @@ const NYPLfromHomeData = {
         rectangularImage: {
           alt: "Man and woman filling out forms in library work area.",
           description: "",
-          'full-uri': "https://d2720ur5668dri.cloudfront.net/sites/default/files/styles/extralarge/public/sites/default/files/multilingual_resources_cr.jpeg",
+          'full-uri': "https://ux-static.nypl.org/images/multilingual_resources_cr.jpeg",
           type: "uri",
         }
       },
@@ -60,7 +60,7 @@ const NYPLfromHomeData = {
         rectangularImage: {
           alt: "Trainer and student working on a tablet computer together.",
           description: "",
-          'full-uri': "https://d2720ur5668dri.cloudfront.net/sites/default/files/styles/extralarge/public/sites/default/files/online_learning_skills_training_for_adults_cr.jpeg",
+          'full-uri': "https://ux-static.nypl.org/images/online_learning_skills_training_for_adults_cr.jpeg",
           type: "uri",
         }
       },
@@ -72,7 +72,7 @@ const NYPLfromHomeData = {
         rectangularImage: {
           alt: "Smiling child doing school homework.",
           description: "",
-          'full-uri': "https://d2720ur5668dri.cloudfront.net/sites/default/files/styles/extralarge/public/sites/default/files/remote_learning_support_kids_teens_educators_cr.jpg",
+          'full-uri': "https://ux-static.nypl.org/images/remote_learning_support_kids_teens_educators_cr.jpg",
           type: "uri",
         }
       },
@@ -84,7 +84,7 @@ const NYPLfromHomeData = {
         rectangularImage: {
           alt: "Computer and a stack of books.",
           description: "",
-          'full-uri': "https://d2720ur5668dri.cloudfront.net/sites/default/files/styles/extralarge/public/sites/default/files/remote_research_at_NYPL_cr.jpeg",
+          'full-uri': "https://ux-static.nypl.org/images/remote_research_at_NYPL_cr.jpeg",
           type: "uri",
         }
       },
@@ -96,7 +96,7 @@ const NYPLfromHomeData = {
         rectangularImage: {
           alt: "Woman reading a magazine.",
           description: "",
-          'full-uri': "https://d2720ur5668dri.cloudfront.net/sites/default/files/styles/extralarge/public/sites/default/files/newspapers_magazines_databases_cr.jpeg",
+          'full-uri': "https://ux-static.nypl.org/images/newspapers_magazines_databases_cr.jpeg",
           type: "uri",
         }
       },
@@ -108,7 +108,7 @@ const NYPLfromHomeData = {
         rectangularImage: {
           alt: "Group of women having a discussion.",
           description: "",
-          'full-uri': "https://d2720ur5668dri.cloudfront.net/sites/default/files/styles/extralarge/public/sites/default/files/covid_19_community_support_resources_cr.jpeg",
+          'full-uri': "https://ux-static.nypl.org/images/covid_19_community_support_resources_cr.jpeg",
           type: "uri",
         }
       },
@@ -120,7 +120,7 @@ const NYPLfromHomeData = {
         rectangularImage: {
           alt: "Librarian helping a young man with a tablet computer.",
           description: "",
-          'full-uri': "https://d2720ur5668dri.cloudfront.net/sites/default/files/styles/extralarge/public/sites/default/files/remote_accessible_resources_cr.jpeg",
+          'full-uri': "https://ux-static.nypl.org/images/remote_accessible_resources_cr.jpeg",
           type: "uri",
         }
       },
@@ -132,7 +132,7 @@ const NYPLfromHomeData = {
         rectangularImage: {
           alt: "Ask a Librarian spelled out in a lightbox with glowing, multi-colored pegs.",
           description: "",
-          'full-uri': "https://d2720ur5668dri.cloudfront.net/sites/default/files/styles/extralarge/public/sites/default/files/get_help_ask_NYPL_cr.jpeg",
+          'full-uri': "https://ux-static.nypl.org/images/get_help_ask_NYPL_cr.jpeg",
           type: "uri",
         }
       },
@@ -144,7 +144,7 @@ const NYPLfromHomeData = {
         rectangularImage: {
           alt: "Closeup of the NYPL lion statue.",
           description: "",
-          'full-uri': "https://d2720ur5668dri.cloudfront.net/sites/default/files/styles/extralarge/public/sites/default/files/get_NYPL_updates_cr.jpeg",
+          'full-uri': "https://ux-static.nypl.org/images/get_NYPL_updates_cr.jpeg",
           type: "uri",
         }
       },


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/RENO-2025)

**This PR does the following:**
- Updates the NYPL from Home image urls to a new static location

**Note:**
- I did not bump the app version as this change only targets the data store