### PR TITLE
New Beanstalk environment for QA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ deploy:
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
   region: us-east-1
   app: nypl-homepage-app
-  env: nypl-homepage-qa
+  env: nypl-homepage-qa-1
   bucket_name: elasticbeanstalk-us-east-1-946183545209
   bucket_path: nypl-homepage-qa
   on:


### PR DESCRIPTION
QA had a Beanstalk platform upgrade, and can only be done via new environment. Updating environment name for subsequent deployments.