### PR TITLE
RENO-2145 Move up Spotlight to top of homepage 

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -70,6 +70,24 @@ class App extends React.Component {
             gaClickEvent={trackComponentEvent()}
           />
 
+        <HomepageRow
+            title={learnSomethingNewData.name}
+            link={learnSomethingNewData.link}
+            className="learnRow hpRow nyplGrid"
+            seeMoreId="learn-seeMore"
+            gaClickEvent={trackHpRowEvent('Learn Something New')}
+            content={
+              <FeatureRow
+                id="hpLearn"
+                className="hpLearn"
+                itemsToDisplay={4}
+                items={learnSomethingNewData.slots}
+                gaClickEvent={trackComponentEvent()}
+                gaActionText="Learn Something New"
+              />
+            }
+          />
+          
           <HomepageRow
             title={whatsHappeningData.name}
             link={whatsHappeningData.link}
@@ -85,24 +103,6 @@ class App extends React.Component {
                 action={Actions.setWhatsHappeningIndexValue}
                 gaClickEvent={trackComponentEvent()}
                 gaActionText="What's Happening"
-              />
-            }
-          />
-
-          <HomepageRow
-            title={learnSomethingNewData.name}
-            link={learnSomethingNewData.link}
-            className="learnRow hpRow nyplGrid"
-            seeMoreId="learn-seeMore"
-            gaClickEvent={trackHpRowEvent('Learn Something New')}
-            content={
-              <FeatureRow
-                id="hpLearn"
-                className="hpLearn"
-                itemsToDisplay={4}
-                items={learnSomethingNewData.slots}
-                gaClickEvent={trackComponentEvent()}
-                gaActionText="Learn Something New"
               />
             }
           />


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-2145)

**This PR does the following:**

- Moves the Spotlight section to the top of the homepage