### PR TITLE
RENO-2145: Change 'NYPL from Home' section title to 'Discover'

### DIFF
--- a/src/app/stores/NYPLfromHomeStore.js
+++ b/src/app/stores/NYPLfromHomeStore.js
@@ -2,7 +2,7 @@ const NYPLfromHomeData = {
   name:
   {
     type: 'text-group',
-    en: { text: 'NYPL from Home', type: 'text-single' }
+    en: { text: 'Discover', type: 'text-single' }
   },
   children: [],
   slots: [


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-2145)

**This PR does the following:**

- Changes the name of the 'NYPL from Home' section title to 'Discover'